### PR TITLE
Fix a couple of issues with generating cloud-init data

### DIFF
--- a/lib/vagrant/action/builtin/cloud_init_setup.rb
+++ b/lib/vagrant/action/builtin/cloud_init_setup.rb
@@ -20,7 +20,7 @@ module Vagrant
 
           if !user_data_configs.empty?
             user_data = setup_user_data(machine, env, user_data_configs)
-            meta_data = { "instance-id": "i-#{machine.id.split('-').join}" }
+            meta_data = { "instance-id" => "i-#{machine.id.split('-').join}" }
 
             write_cfg_iso(machine, env, user_data, meta_data)
           end
@@ -97,7 +97,7 @@ module Vagrant
               source_dir = Pathname.new(Dir.mktmpdir(TEMP_PREFIX))
               File.open("#{source_dir}/user-data", 'w') { |file| file.write(user_data.to_s) }
 
-              File.open("#{source_dir}/meta-data", 'w') { |file| file.write(meta_data.to_s) }
+              File.open("#{source_dir}/meta-data", 'w') { |file| file.write(meta_data.to_yaml) }
 
               iso_path = env[:env].host.capability(:create_iso,
                                                    source_dir, volume_id: "cidata")

--- a/lib/vagrant/action/builtin/cloud_init_setup.rb
+++ b/lib/vagrant/action/builtin/cloud_init_setup.rb
@@ -73,6 +73,7 @@ module Vagrant
         # @return [MIME::Multipart::Mixed] msg
         def generate_cfg_msg(machine, text_cfgs)
           msg = MIME::Multipart::Mixed.new
+          msg.headers.set("MIME-Version", "1.0")
 
           text_cfgs.each do |c|
             msg.add(c)

--- a/test/unit/vagrant/action/builtin/cloud_init_setup_test.rb
+++ b/test/unit/vagrant/action/builtin/cloud_init_setup_test.rb
@@ -86,6 +86,11 @@ describe Vagrant::Action::Builtin::CloudInitSetup do
       message = subject.generate_cfg_msg(machine, text_cfgs)
       expect(message).to be_a(MIME::Multipart::Mixed)
     end
+
+    it "sets a MIME-Version header" do
+      message = subject.generate_cfg_msg(machine, text_cfgs)
+      expect(message.headers.get("MIME-Version")).to eq("1.0")
+    end
   end
 
   describe "#write_cfg_iso" do


### PR DESCRIPTION
This PR fixes two issues with generating the cloud-init data:

1. cloud-init seems to need a `MIME-Version` header set in the multipart message. Otherwise it will raise an error like:

> 2020-07-31 14:37:17,200 - __init__.py[WARNING]: Unhandled non-multipart (text/x-not-multipart) userdata: 'b'Content-Type: multipart/'...'

2. The generated `meta-data` file should be written as YAML.